### PR TITLE
feat(logic): implement basic functionality

### DIFF
--- a/source/production/F0.Minesweeper.Logic.Abstractions/MinefieldOptions.cs
+++ b/source/production/F0.Minesweeper.Logic.Abstractions/MinefieldOptions.cs
@@ -4,13 +4,13 @@ namespace F0.Minesweeper.Logic.Abstractions
 {
 	public sealed record MinefieldOptions(uint Width, uint Height, uint MineCount)
 	{
-		public static MinefieldOptions Easy()
-			=> throw new NotImplementedException();
+		public static MinefieldOptions Easy
+			=> new MinefieldOptions(10, 8, 10);
 
-		public static MinefieldOptions Medium()
-			=> throw new NotImplementedException();
+		public static MinefieldOptions Medium
+			=> new MinefieldOptions(18, 14, 40);
 
-		public static MinefieldOptions Hard()
-			=> throw new NotImplementedException();
+		public static MinefieldOptions Hard
+			=> new MinefieldOptions(24, 20, 99);
 	}
 }

--- a/source/production/F0.Minesweeper.Logic/GameUpdateReport.cs
+++ b/source/production/F0.Minesweeper.Logic/GameUpdateReport.cs
@@ -3,16 +3,16 @@ using F0.Minesweeper.Logic.Abstractions;
 
 namespace F0.Minesweeper.Logic
 {
-	public class GameUpdateReport : IGameUpdateReport
+	internal class GameUpdateReport : IGameUpdateReport
 	{
 		public GameStatus Status { get; private set; }
 
 		public IUncoveredCell[] Cells { get; private set; }
 
-		public GameUpdateReport(GameStatus status, IUncoveredCell[] cells)
+		internal GameUpdateReport(GameStatus status, IUncoveredCell[] cells)
 		{
 			Status = status;
-			Cells = cells ?? throw new ArgumentNullException(nameof(cells));
+			Cells = cells;
 		}
 	}
 }

--- a/source/production/F0.Minesweeper.Logic/GameUpdateReport.cs
+++ b/source/production/F0.Minesweeper.Logic/GameUpdateReport.cs
@@ -1,4 +1,3 @@
-using System;
 using F0.Minesweeper.Logic.Abstractions;
 
 namespace F0.Minesweeper.Logic

--- a/source/production/F0.Minesweeper.Logic/GameUpdateReport.cs
+++ b/source/production/F0.Minesweeper.Logic/GameUpdateReport.cs
@@ -1,0 +1,18 @@
+using System;
+using F0.Minesweeper.Logic.Abstractions;
+
+namespace F0.Minesweeper.Logic
+{
+	public class GameUpdateReport : IGameUpdateReport
+	{
+		public GameStatus Status { get; private set; }
+
+		public IUncoveredCell[] Cells { get; private set; }
+
+		public GameUpdateReport(GameStatus status, IUncoveredCell[] cells)
+		{
+			Status = status;
+			Cells = cells ?? throw new ArgumentNullException(nameof(cells));
+		}
+	}
+}

--- a/source/production/F0.Minesweeper.Logic/Location.cs
+++ b/source/production/F0.Minesweeper.Logic/Location.cs
@@ -1,0 +1,16 @@
+using F0.Minesweeper.Logic.Abstractions;
+
+namespace F0.Minesweeper.Logic
+{
+	public class Location : ILocation
+	{
+		public uint X { get; private set; }
+		public uint Y { get; private set; }
+
+		internal Location(uint x, uint y)
+		{
+			X = x;
+			Y = y;
+		}
+	}
+}

--- a/source/production/F0.Minesweeper.Logic/Location.cs
+++ b/source/production/F0.Minesweeper.Logic/Location.cs
@@ -1,16 +1,19 @@
+using System.Runtime.CompilerServices;
 using F0.Minesweeper.Logic.Abstractions;
 
 namespace F0.Minesweeper.Logic
 {
-	public class Location : ILocation
+	public record Location : ILocation
 	{
-		public uint X { get; private set; }
-		public uint Y { get; private set; }
+		public uint X { get; init; }
+		public uint Y { get; init; }
 
 		internal Location(uint x, uint y)
 		{
 			X = x;
 			Y = y;
 		}
+
+		internal Location() : this(0u, 0u) { }
 	}
 }

--- a/source/production/F0.Minesweeper.Logic/Location.cs
+++ b/source/production/F0.Minesweeper.Logic/Location.cs
@@ -1,4 +1,3 @@
-using System.Runtime.CompilerServices;
 using F0.Minesweeper.Logic.Abstractions;
 
 namespace F0.Minesweeper.Logic

--- a/source/production/F0.Minesweeper.Logic/Minefield.cs
+++ b/source/production/F0.Minesweeper.Logic/Minefield.cs
@@ -2,7 +2,7 @@ using F0.Minesweeper.Logic.Abstractions;
 
 namespace F0.Minesweeper.Logic
 {
-	public class Minefield : IMinefield
+	internal sealed class Minefield : IMinefield
 	{
 		private readonly uint width, height, mineCount;
 
@@ -11,6 +11,13 @@ namespace F0.Minesweeper.Logic
 			this.width = width;
 			this.height = height;
 			this.mineCount = mineCount;
+		}
+
+		internal Minefield(MinefieldOptions minefieldOptions)
+		{
+			width = minefieldOptions.Width;
+			height = minefieldOptions.Height;
+			mineCount = minefieldOptions.MineCount;
 		}
 
 		public IGameUpdateReport Uncover(uint x, uint y) => Uncover(new Location(x, y));

--- a/source/production/F0.Minesweeper.Logic/Minefield.cs
+++ b/source/production/F0.Minesweeper.Logic/Minefield.cs
@@ -1,0 +1,26 @@
+using F0.Minesweeper.Logic.Abstractions;
+
+namespace F0.Minesweeper.Logic
+{
+	public class Minefield : IMinefield
+	{
+		private readonly uint width, height, mineCount;
+
+		internal Minefield(uint width, uint height, uint mineCount)
+		{
+			this.width = width;
+			this.height = height;
+			this.mineCount = mineCount;
+		}
+
+		public IGameUpdateReport Uncover(uint x, uint y) => Uncover(new Location(x, y));
+		public IGameUpdateReport Uncover(ILocation location)
+		{
+			// TODO: implement real logic
+			return new GameUpdateReport(GameStatus.InProgress,
+				new IUncoveredCell[] {
+					new UncoveredCell(new Location(location.X, location.Y), false, 1)
+				});
+		}
+	}
+}

--- a/source/production/F0.Minesweeper.Logic/MinefieldFactory.cs
+++ b/source/production/F0.Minesweeper.Logic/MinefieldFactory.cs
@@ -1,0 +1,10 @@
+using F0.Minesweeper.Logic.Abstractions;
+
+namespace F0.Minesweeper.Logic
+{
+	public class MinefieldFactory : IMinefieldFactory
+	{
+		public IMinefield Create(MinefieldOptions options)
+			=> new Minefield(options.Width, options.Height, options.MineCount);
+	}
+}

--- a/source/production/F0.Minesweeper.Logic/UncoveredCell.cs
+++ b/source/production/F0.Minesweeper.Logic/UncoveredCell.cs
@@ -1,0 +1,19 @@
+using System;
+using F0.Minesweeper.Logic.Abstractions;
+
+namespace F0.Minesweeper.Logic
+{
+	public class UncoveredCell : IUncoveredCell
+	{
+		public ILocation Location { get; private set; }
+		public bool IsMine { get; private set; }
+		public byte AdjacentMineCount { get; private set; }
+
+		internal UncoveredCell(ILocation location, bool isMine, byte adjacentMineCount)
+		{
+			Location = location ?? throw new ArgumentNullException(nameof(location));
+			IsMine = isMine;
+			AdjacentMineCount = adjacentMineCount;
+		}
+	}
+}

--- a/source/production/F0.Minesweeper.Logic/UncoveredCell.cs
+++ b/source/production/F0.Minesweeper.Logic/UncoveredCell.cs
@@ -1,9 +1,8 @@
-using System;
 using F0.Minesweeper.Logic.Abstractions;
 
 namespace F0.Minesweeper.Logic
 {
-	public class UncoveredCell : IUncoveredCell
+	internal class UncoveredCell : IUncoveredCell
 	{
 		public ILocation Location { get; private set; }
 		public bool IsMine { get; private set; }
@@ -11,7 +10,7 @@ namespace F0.Minesweeper.Logic
 
 		internal UncoveredCell(ILocation location, bool isMine, byte adjacentMineCount)
 		{
-			Location = location ?? throw new ArgumentNullException(nameof(location));
+			Location = location;
 			IsMine = isMine;
 			AdjacentMineCount = adjacentMineCount;
 		}

--- a/source/test/F0.Minesweeper.Logic.Tests/LocationTest.cs
+++ b/source/test/F0.Minesweeper.Logic.Tests/LocationTest.cs
@@ -1,0 +1,35 @@
+using FluentAssertions;
+using Xunit;
+
+namespace F0.Minesweeper.Logic.Tests
+{
+	public class LocationTest
+	{
+		[Fact]
+		public void NewLocation_XParameterEqualsX()
+		{
+			uint testValue = 5;
+			var locationUnderTest = new Location(testValue, 7);
+
+			locationUnderTest.X.Should().Be(testValue);
+		}
+
+		[Fact]
+		public void NewLocation_YParameterEqualsY()
+		{
+			uint testValue = 7;
+			var locationUnderTest = new Location(5, testValue);
+
+			locationUnderTest.Y.Should().Be(testValue);
+		}
+
+		[Fact]
+		public void NewLocation_MaxIntParameter()
+		{
+			uint testValue = int.MaxValue;
+			var locationUnderTest = new Location(testValue, 7);
+
+			locationUnderTest.X.Should().Be(testValue);
+		}
+	}
+}

--- a/source/test/F0.Minesweeper.Logic.Tests/LocationTest.cs
+++ b/source/test/F0.Minesweeper.Logic.Tests/LocationTest.cs
@@ -31,5 +31,14 @@ namespace F0.Minesweeper.Logic.Tests
 
 			locationUnderTest.X.Should().Be(testValue);
 		}
+
+		[Fact]
+		public void NewLocationEmptyConstructor_CreatesZeroLocation()
+		{
+			var locationUnderTest = new Location();
+
+			locationUnderTest.X.Should().Be(0);
+			locationUnderTest.Y.Should().Be(0);
+		}
 	}
 }

--- a/source/test/F0.Minesweeper.Logic.Tests/LocationTest.cs
+++ b/source/test/F0.Minesweeper.Logic.Tests/LocationTest.cs
@@ -24,12 +24,21 @@ namespace F0.Minesweeper.Logic.Tests
 		}
 
 		[Fact]
-		public void NewLocation_MaxIntParameter()
+		public void NewLocation_MaxIntParameterOnX()
 		{
 			uint testValue = int.MaxValue;
 			var locationUnderTest = new Location(testValue, 7);
 
 			locationUnderTest.X.Should().Be(testValue);
+		}
+
+		[Fact]
+		public void NewLocation_MaxIntParameterOnY()
+		{
+			uint testValue = int.MaxValue;
+			var locationUnderTest = new Location(5, testValue);
+
+			locationUnderTest.Y.Should().Be(testValue);
 		}
 
 		[Fact]

--- a/source/test/F0.Minesweeper.Logic.Tests/MinefieldOptionsTest.cs
+++ b/source/test/F0.Minesweeper.Logic.Tests/MinefieldOptionsTest.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using F0.Minesweeper.Logic.Abstractions;
+using FluentAssertions;
+using Xunit;
+
+namespace F0.Minesweeper.Logic.Tests
+{
+	public class MinefieldOptionsTest
+	{
+		private readonly MinefieldOptions easy = MinefieldOptions.Easy;
+		private readonly MinefieldOptions medium = MinefieldOptions.Medium;
+		private readonly MinefieldOptions hard = MinefieldOptions.Hard;
+
+		[Fact]
+		public void RisingDifficultyLevel_Should_IncreaseMinefieldHeightAndWidth()
+		{
+			medium.Height.Should().BeGreaterThan(easy.Height);
+			hard.Height.Should().BeGreaterThan(medium.Height);
+
+			medium.Width.Should().BeGreaterThan(easy.Width);
+			hard.Width.Should().BeGreaterThan(medium.Width);
+		}
+
+		[Fact]
+		public void RisingDifficultyLevel_Should_IncreaseMineCountInMinefield()
+		{
+			medium.MineCount.Should().BeGreaterThan(easy.MineCount);
+			hard.MineCount.Should().BeGreaterThan(medium.MineCount);
+		}
+	}
+}

--- a/source/test/F0.Minesweeper.Logic.Tests/MinefieldOptionsTest.cs
+++ b/source/test/F0.Minesweeper.Logic.Tests/MinefieldOptionsTest.cs
@@ -1,8 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using F0.Minesweeper.Logic.Abstractions;
 using FluentAssertions;
 using Xunit;

--- a/source/test/F0.Minesweeper.Logic.Tests/MinefieldTest.cs
+++ b/source/test/F0.Minesweeper.Logic.Tests/MinefieldTest.cs
@@ -1,0 +1,20 @@
+using FluentAssertions;
+using Xunit;
+
+namespace F0.Minesweeper.Logic.Tests
+{
+	public class MinefieldTest
+	{
+		[Fact]
+		public void MinefieldUncover_Should_ReturnAtLeastTheClickedLocation()
+		{
+			var minefieldUnderTest = new Minefield(5, 7, 11);
+			var locationTestValue = new Location(3, 4);
+
+			var result = minefieldUnderTest.Uncover(locationTestValue);
+
+			result.Cells.Should().NotBeEmpty()
+				.And.ContainSingle(cell => (Location)cell.Location == locationTestValue);
+		}
+	}
+}


### PR DESCRIPTION
Heya! I think this could be some minimal game logic functionality that can be used by the server 😄
This implementation just adds the basic data classes which are needed, so that the server can create a Minefield. The ```Uncover``` method just returns a GameStatus "In Progress" and one cell with the given Location, is no mine and has "1" adjacent mine.

Apart from that, I changed the Easy/Medium/Hard difficulties to properties (were methods before).

I hope I did everything right so far (regarding our GitHub-Flow-Branching-ConventionalCommitting-Workflow 😜)

Closes #6 
(... I guess 🙈)